### PR TITLE
Remove HHVM from Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
 - 5.5
 - 5.6
 - 7.0
-- hhvm
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
A simple PR to just remove HHVM from Travis config file and make tests passing. 😎

```
PHPUnit 6.3.0 by Sebastian Bergmann and contributors.

.....................                                             21 / 21 (100%)

Time: 373 ms, Memory: 24.00MB

OK (21 tests, 36 assertions)
```

> HHVM is not supported by PHPUnit 6 (which requires PHP 7+)