### PR TITLE
Fixes 500 status when an address field is an unexpected array

### DIFF
--- a/src/Support/Validation/Rules/AdministrativeAreaCodeRule.php
+++ b/src/Support/Validation/Rules/AdministrativeAreaCodeRule.php
@@ -27,7 +27,11 @@ class AdministrativeAreaCodeRule implements Rule
 	 */
 	public function passes($attribute, $value) : bool
 	{
-		return null !== $this->country->administrativeArea($value);
+        if (!is_string($value)) {
+            return false;
+        }
+
+        return null !== $this->country->administrativeArea($value);
 	}
 	
 	/**

--- a/src/Support/Validation/Rules/AdministrativeAreaNameRule.php
+++ b/src/Support/Validation/Rules/AdministrativeAreaNameRule.php
@@ -27,7 +27,11 @@ class AdministrativeAreaNameRule implements Rule
 	 */
 	public function passes($attribute, $value) : bool
 	{
-		return null !== $this->country->administrativeAreaByName($value);
+        if (!is_string($value)) {
+            return false;
+        }
+
+        return null !== $this->country->administrativeAreaByName($value);
 	}
 	
 	/**

--- a/src/Support/Validation/Rules/CountryCodeRule.php
+++ b/src/Support/Validation/Rules/CountryCodeRule.php
@@ -27,6 +27,10 @@ class CountryCodeRule implements Rule
 	 */
 	public function passes($attribute, $value) : bool
 	{
+        if (!is_string($value)) {
+            return false;
+        }
+
 		return null !== $this->addressing->country($value);
 	}
 	

--- a/src/Support/Validation/Rules/CountryNameRule.php
+++ b/src/Support/Validation/Rules/CountryNameRule.php
@@ -27,6 +27,10 @@ class CountryNameRule implements Rule
 	 */
 	public function passes($attribute, $value) : bool
 	{
+        if (!is_string($value)) {
+            return false;
+        }
+
 		return null !== $this->addressing->countryByName($value);
 	}
 	

--- a/src/Support/Validation/Rules/PostalCodeRule.php
+++ b/src/Support/Validation/Rules/PostalCodeRule.php
@@ -36,7 +36,11 @@ class PostalCodeRule implements Rule
 	 */
 	public function passes($attribute, $value) : bool
 	{
-		// If we don't have a pattern for this country/area, automatically pass
+        if (!is_string($value)) {
+            return false;
+        }
+
+        // If we don't have a pattern for this country/area, automatically pass
 		if (!$pattern = $this->pattern()) {
 			return true;
 		}

--- a/tests/Validator/AdministrativeAreaValidatorTest.php
+++ b/tests/Validator/AdministrativeAreaValidatorTest.php
@@ -49,6 +49,30 @@ class AdministrativeAreaValidatorTest extends BaseValidatorTestCase
         ]));
     }
 
+    public function testAdminAreaCodeArrayIsInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => 'US', 'state' => ['CO']],
+            'rules' => ['state' => 'administrative_area_code:country'],
+        ]));
+    }
+
+    public function testAdminAreaNameArrayIsInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => 'US', 'state' => ['Colorado']],
+            'rules' => ['state' => 'administrative_area_name:country'],
+        ]));
+    }
+
+    public function testGeneralAdminAreaArrayIsInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => 'US', 'state' => ['CO']],
+            'rules' => ['state' => 'administrative_area:country'],
+        ]));
+    }
+
     public function testUSStateByName()
     {
         // Valid state in US

--- a/tests/Validator/CountryValidatorTest.php
+++ b/tests/Validator/CountryValidatorTest.php
@@ -25,6 +25,14 @@ class CountryValidatorTest extends BaseValidatorTestCase
         ]));
     }
 
+    public function testCountryCodeArrayIsInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => ['US']],
+            'rules' => ['country' => 'country_code'],
+        ]));
+    }
+
     public function testCorrectCountryCode()
     {
         $this->assertTrue($this->performValidation([
@@ -45,11 +53,51 @@ class CountryValidatorTest extends BaseValidatorTestCase
         ]));
     }
 
+    public function testCountryNameArrayIsInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => ['United States']],
+            'rules' => ['country' => 'country_name'],
+        ]));
+    }
+
     public function testCorrectCountryName()
     {
         $this->assertTrue($this->performValidation([
             'data' => ['country' => 'United States'],
             'rules' => ['country' => 'country_name'],
+        ]));
+    }
+
+    public function testGeneralCountryValidation()
+    {
+        // Valid country code
+        $this->assertTrue($this->performValidation([
+            'data' => ['country' => 'US'],
+            'rules' => ['country' => 'country'],
+        ]));
+        // Invalid country code
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => 'ZZ'],
+            'rules' => ['country' => 'country'],
+        ]));
+        // Valid country using its name
+        $this->assertTrue($this->performValidation([
+            'data' => ['country' => 'United States'],
+            'rules' => ['country' => 'country'],
+        ]));
+        // Invalid country using its name
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => 'United Stattes'],
+            'rules' => ['country' => 'country'],
+        ]));
+    }
+
+    public function testGeneralCountryArrayIsInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => ['United States']],
+            'rules' => ['country' => 'country'],
         ]));
     }
 }

--- a/tests/Validator/PostalCodeValidatorTest.php
+++ b/tests/Validator/PostalCodeValidatorTest.php
@@ -25,6 +25,14 @@ class PostalCodeValidatorTest extends BaseValidatorTestCase
         ]));
     }
 
+    public function testArrayPostalCodeInvalid()
+    {
+        $this->assertFalse($this->performValidation([
+            'data' => ['country' => 'US', 'state' => 'CO', 'code' => ['80301']],
+            'rules' => ['code' => 'postal_code:country,state'],
+        ]));
+    }
+
     public function testBrazilianPostalCodes()
     {
         $this->assertTrue($this->performValidation([


### PR DESCRIPTION
Added some tests to ensure validation gracefully fails when the input is not a string.

Closes #11 