### PR TITLE
Update composer.json to allow 6.0 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
 	],
 	"require": {
 		"php": "^7.1.3",
-		"illuminate/contracts": "~5.7.0|~5.8.0|~6.0.0",
-		"illuminate/support": "~5.7.0|~5.8.0|~6.0.0",
-		"illuminate/http": "~5.7.0|~5.8.0|~6.0.0",
-		"illuminate/routing": "~5.7.0|~5.8.0|~6.0.0",
-		"illuminate/validation": "~5.7.0|~5.8.0|~6.0.0",
+		"illuminate/contracts": "~5.7.0|~5.8.0|^6.0",
+		"illuminate/support": "~5.7.0|~5.8.0|^6.0",
+		"illuminate/http": "~5.7.0|~5.8.0|^6.0",
+		"illuminate/routing": "~5.7.0|~5.8.0|^6.0",
+		"illuminate/validation": "~5.7.0|~5.8.0|^6.0",
 		"commerceguys/addressing": "^1.0",
 		"symfony/intl": "^4.2",
 		"commerceguys/intl": "^1.0"


### PR DESCRIPTION
Laravel moved to semantic versioning, so the latest package is already 6.6.1.

This is the package configuration to allow Laravel v6.